### PR TITLE
fixed2

### DIFF
--- a/src/HRProject/Bugs/Paginator.php
+++ b/src/HRProject/Bugs/Paginator.php
@@ -12,9 +12,9 @@ class Paginator
     {
         $select->setLimit(null);
         $select->setOffset(null);
-        $select->setColumns(array('COUNT(*)'));
+        $select->setColumns(array('COUNT(*) as rate'));
         $db = new DbGateway();
 
         return $db->execute($select, \PDO::FETCH_COLUMN);
     }
-} 
+}  


### PR DESCRIPTION
В классе Paginator в строке $select->setColumns() было значение COUNT(*) из за чего итоговый запрос выглядел как SELECT COUNT(*) FROM search_institutions ORDERY BY rate desc в котором он не мог найти значение rate